### PR TITLE
Linux installer fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# EditorConfig is awesome: https://editorconfig.org
+
+root = true
+
+[*.sh]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = tab
+indent_size = 4

--- a/Linux/ut99-installer.sh
+++ b/Linux/ut99-installer.sh
@@ -39,7 +39,7 @@ isInstalled() {
 		debian_package="$1"
 		others_package="$1"
 	fi
-	
+
 	# Ubuntu/Debian/Mint/...
 	if command -v dpkg > /dev/null 2>&1
 	then
@@ -48,7 +48,7 @@ isInstalled() {
 	elif command -v rpm > /dev/null 2>&1
 	then
 		rpm -q "$others_package" > /dev/null 2>&1
-    # arch/manjaro/...		
+	# arch/manjaro/...
 	elif command -v pacman > /dev/null 2>&1
 	then
 		pacman -Qi "$others_package" > /dev/null 2>&1
@@ -81,7 +81,7 @@ checkDependencies() {
 getUTFiles() {
 	mkdir $game_folder
 	cd $game_folder
-	
+
 	echo "Downloading $game_name files..."
 	wget -nv --show-progress "$iso_url"
 	echo -e "\xE2\x9C\x94 $game_name files downloaded"
@@ -121,29 +121,29 @@ getLatestRelease() {
 getArchitecture() {
 	case $(uname -m) in
 		x86_64)
-    		arc_suffix='amd64'
-    		system_suffix='64'
-    		url_download=$(cat ./patch_latest | jq -r '.assets[0].browser_download_url')
-    		;;
-    	aarch64)
-    		arc_suffix='arm64'
-    		system_suffix='ARM64'
-    		url_download=$(cat ./patch_latest | jq -r '.assets[1].browser_download_url')
-    		;;
+			arc_suffix='amd64'
+			system_suffix='64'
+			url_download=$(cat ./patch_latest | jq -r '.assets[0].browser_download_url')
+			;;
+		aarch64)
+			arc_suffix='arm64'
+			system_suffix='ARM64'
+			url_download=$(cat ./patch_latest | jq -r '.assets[1].browser_download_url')
+			;;
 		i386)
 			arc_suffix='x86'
-    		system_suffix=''
-    		url_download=$(cat ./patch_latest | jq -r '.assets[2].browser_download_url')
+			system_suffix=''
+			url_download=$(cat ./patch_latest | jq -r '.assets[2].browser_download_url')
 			;;
-    	i686)
-    		arc_suffix='x86'
-    		system_suffix=''
-    		url_download=$(cat ./patch_latest | jq -r '.assets[2].browser_download_url')
-    		;;
-    	*)
-    		echo "Unknown architecture"
-    		exit 0
-    		;; 	
+		i686)
+			arc_suffix='x86'
+			system_suffix=''
+			url_download=$(cat ./patch_latest | jq -r '.assets[2].browser_download_url')
+			;;
+		*)
+			echo "Unknown architecture"
+			exit 0
+			;;
 	esac
 }
 
@@ -158,7 +158,7 @@ getPatch() {
 	patch_tar="./$game_folder/patch$patch_ver.tar.bz2"
 	mv ./$game_folder/*.tar.bz2 $patch_tar
 	tar -xf $patch_tar -C ./$game_folder/ --overwrite
-	rm ./patch_latest	
+	rm ./patch_latest
 	echo -e "\xE2\x9C\x94 Patch added"
 }
 
@@ -177,54 +177,54 @@ decompressMaps() {
 			rm $file
 		else
 			echo "Failed to decompress $file"
-		fi		
+		fi
 	done
 	echo
-	echo -e "\xE2\x9C\x94 $count maps decompressed"		
+	echo -e "\xE2\x9C\x94 $count maps decompressed"
 }
 
 addLinks() {
 	read -p "Add a .desktop entry?(Y/n) " desktop_entry
 	read -p "Add a menu entry?(Y/n) " app_entry
-	
+
 	if [[ -z $desktop_entry ]]; then
-    	desktop_entry='y'
+		desktop_entry='y'
 	fi
 	if [[ -z $app_entry ]]; then
-    	app_entry='y'
+		app_entry='y'
 	fi
 
 	if [[ $desktop_entry =~ ^[Yy]$ || $app_entry =~ ^[Yy]$ ]]; then
-    	echo "Creating entry..."
-    	echo "[Desktop Entry]" > $launcher_name
-    	echo "Version=$patch_ver" >> $launcher_name
-    	echo "Name=$game_name" >> $launcher_name
-    	echo "Comment=$game_name" >> $launcher_name
-    	echo "Exec=$curr_path/$game_folder/System$system_suffix/$game_executable$arc_suffix" >> $launcher_name
+		echo "Creating entry..."
+		echo "[Desktop Entry]" > $launcher_name
+		echo "Version=$patch_ver" >> $launcher_name
+		echo "Name=$game_name" >> $launcher_name
+		echo "Comment=$game_name" >> $launcher_name
+		echo "Exec=$curr_path/$game_folder/System$system_suffix/$game_executable$arc_suffix" >> $launcher_name
 		echo "Icon=$curr_path/$game_folder/System/Unreal.ico" >> $launcher_name
 		echo "Terminal=false" >> $launcher_name
-	    echo "Type=Application" >> $launcher_name
-	    echo "Categories=ApplicationCategory;" >> $launcher_name
-	    chmod +x $launcher_name
+		echo "Type=Application" >> $launcher_name
+		echo "Categories=ApplicationCategory;" >> $launcher_name
+		chmod +x $launcher_name
 
-	    if [[ $desktop_entry =~ ^[Yy]$ ]]; then
-	    	cp $launcher_name ~/Desktop/
-	    	echo -e "\xE2\x9C\x94 .desktop entry created"
-	    fi
-		
-	    if [[ $app_entry =~ ^[Yy]$ ]]; then
-	    	cp $launcher_name ~/.local/share/applications/
-	    	echo -e "\xE2\x9C\x94 Menu entry created"
-	    fi
-	    rm $launcher_name
+		if [[ $desktop_entry =~ ^[Yy]$ ]]; then
+			cp $launcher_name ~/Desktop/
+			echo -e "\xE2\x9C\x94 .desktop entry created"
+		fi
+
+		if [[ $app_entry =~ ^[Yy]$ ]]; then
+			cp $launcher_name ~/.local/share/applications/
+			echo -e "\xE2\x9C\x94 Menu entry created"
+		fi
+		rm $launcher_name
 	fi
 }
 
 deleteDownFiles() {
 	read -p "Delete downloaded files?(Y/n) " del_download
-	
+
 	if [[ -z $del_download ]]; then
-    	del_download='y'
+		del_download='y'
 	fi
 
 	if [[ $del_download =~ ^[Yy]$ ]]; then

--- a/Linux/ut99-installer.sh
+++ b/Linux/ut99-installer.sh
@@ -114,7 +114,7 @@ deleteUnnecessaryFiles() {
 getLatestRelease() {
 	echo "Downloading latest patch release list..."
 	wget -q -O patch_latest $latest_release
-	patch_ver=$(cat ./patch_latest | jq -r '.tag_name')
+	patch_ver=$(jq -r '.tag_name' ./patch_latest)
 	echo -e "\xE2\x9C\x94 Release list downloaded"
 }
 
@@ -123,22 +123,22 @@ getArchitecture() {
 		x86_64)
 			arc_suffix='amd64'
 			system_suffix='64'
-			url_download=$(cat ./patch_latest | jq -r '.assets[0].browser_download_url')
+			url_download=$(jq -r '.assets[0].browser_download_url' ./patch_latest)
 			;;
 		aarch64)
 			arc_suffix='arm64'
 			system_suffix='ARM64'
-			url_download=$(cat ./patch_latest | jq -r '.assets[1].browser_download_url')
+			url_download=$(jq -r '.assets[1].browser_download_url' ./patch_latest)
 			;;
 		i386)
 			arc_suffix='x86'
 			system_suffix=''
-			url_download=$(cat ./patch_latest | jq -r '.assets[2].browser_download_url')
+			url_download=$(jq -r '.assets[2].browser_download_url' ./patch_latest)
 			;;
 		i686)
 			arc_suffix='x86'
 			system_suffix=''
-			url_download=$(cat ./patch_latest | jq -r '.assets[2].browser_download_url')
+			url_download=$(jq -r '.assets[2].browser_download_url' ./patch_latest)
 			;;
 		*)
 			echo "Unknown architecture"

--- a/Linux/ut99-installer.sh
+++ b/Linux/ut99-installer.sh
@@ -244,9 +244,9 @@ deleteDownFiles() {
 addUninstall() {
 	echo "Creating uninstall script..."
 	echo 'cd "$(dirname "$0")"' > uninstall.sh
-	echo "rm -r ../${game_folder}" >> uninstall.sh
+	echo "rm -r '../${game_folder}'" >> uninstall.sh
 	echo "rm -f '${desktop_dir}/${launcher_name}'" >> uninstall.sh
-	echo "rm -f ~/.local/share/applications/${launcher_name}" >> uninstall.sh
+	echo "rm -f '~/.local/share/applications/${launcher_name}'" >> uninstall.sh
 	chmod +x uninstall.sh
 	mv uninstall.sh "./${game_folder}"
 	echo -e "\xE2\x9C\x94 Uninstall script created"

--- a/Linux/ut99-installer.sh
+++ b/Linux/ut99-installer.sh
@@ -184,8 +184,8 @@ decompressMaps() {
 }
 
 addLinks() {
-	read -p "Add a .desktop entry?(Y/n) " desktop_entry
-	read -p "Add a menu entry?(Y/n) " app_entry
+	read -r -p "Add a .desktop entry?(Y/n) " desktop_entry
+	read -r -p "Add a menu entry?(Y/n) " app_entry
 
 	if [[ -z "$desktop_entry" ]]; then
 		desktop_entry='y'
@@ -221,7 +221,7 @@ addLinks() {
 }
 
 deleteDownFiles() {
-	read -p "Delete downloaded files?(Y/n) " del_download
+	read -r -p "Delete downloaded files?(Y/n) " del_download
 
 	if [[ -z "$del_download" ]]; then
 		del_download='y'

--- a/Linux/ut99-installer.sh
+++ b/Linux/ut99-installer.sh
@@ -8,7 +8,7 @@ setVariables() {
 	game_name="Unreal Tournament"
 	game_folder='UnrealTournament'
 	iso_name='UT_GOTY_CD1.ISO'
-	iso_url="https://files.oldunreal.net/$iso_name"
+	iso_url="https://files.oldunreal.net/${iso_name}"
 	latest_release='https://api.github.com/repos/OldUnreal/UnrealTournamentPatches/releases/latest'
 	delete_folders="
 DirectX7
@@ -82,9 +82,9 @@ getUTFiles() {
 	mkdir $game_folder
 	cd $game_folder
 
-	echo "Downloading $game_name files..."
+	echo "Downloading ${game_name} files..."
 	wget -nv --show-progress "$iso_url"
-	echo -e "\xE2\x9C\x94 $game_name files downloaded"
+	echo -e "\xE2\x9C\x94 ${game_name} files downloaded"
 
 	echo "Extracting files..."
 	7z x $iso_name -y
@@ -98,14 +98,14 @@ deleteUnnecessaryFiles() {
 	do
 		if [ -d "$game_folder/$folder" ]
 		then
-			echo "Deleting folder $game_folder/$folder"
-			rm -rf "$game_folder/$folder"
+			echo "Deleting folder ${game_folder}/${folder}"
+			rm -rf "${game_folder}/${folder}"
 		fi
 	done
 	for extension in $delete_extensions
 	do
-		echo "Deleting $game_folder/System/*.$extension"
-		rm $game_folder/System/*.$extension
+		echo "Deleting ${game_folder}/System/*.${extension}"
+		rm ${game_folder}/System/*.${extension}
 	done
 	echo -e "\xE2\x9C\x94 Unnecessary files deleted"
 }
@@ -150,14 +150,14 @@ getArchitecture() {
 getPatch() {
 	getLatestRelease
 	getArchitecture
-	echo "Downloading patch $patch_ver"
+	echo "Downloading patch ${patch_ver}"
 	wget -P ./$game_folder -nv --show-progress $url_download
 	echo -e "\xE2\x9C\x94 Patch downloaded"
 
 	echo "Extracting and adding patch..."
-	patch_tar="./$game_folder/patch$patch_ver.tar.bz2"
-	mv ./$game_folder/*.tar.bz2 $patch_tar
-	tar -xf $patch_tar -C ./$game_folder/ --overwrite
+	patch_tar="./${game_folder}/patch${patch_ver}.tar.bz2"
+	mv ./${game_folder}/*.tar.bz2 $patch_tar
+	tar -xf $patch_tar -C ./${game_folder}/ --overwrite
 	rm ./patch_latest
 	echo -e "\xE2\x9C\x94 Patch added"
 }
@@ -165,22 +165,22 @@ getPatch() {
 decompressMaps() {
 	echo "Decompressing maps"
 	count=0
-	for file in `ls -1 $game_folder/Maps/*.unr.uz`
+	for file in `ls -1 ${game_folder}/Maps/*.unr.uz`
 	do
-		$game_folder/System$system_suffix/ucc-bin-$arc_suffix "decompress" "$curr_path/$file" "-nohomedir" > /dev/null 2>&1
+		${game_folder}/System${system_suffix}/ucc-bin-${arc_suffix} "decompress" "${curr_path}/${file}" "-nohomedir" > /dev/null 2>&1
 		basename=`echo $file | cut -d'/' -f3 | sed 's/\.uz//'`
-		if [ -e "$game_folder/System$system_suffix/$basename" ]
+		if [ -e "${game_folder}/System${system_suffix}/${basename}" ]
 		then
 			echo -n '.'
 			count=$((count + 1))
-			mv "$game_folder/System$system_suffix/$basename" "$game_folder/Maps/"
+			mv "${game_folder}/System${system_suffix}/${basename}" "${game_folder}/Maps/"
 			rm $file
 		else
-			echo "Failed to decompress $file"
+			echo "Failed to decompress ${file}"
 		fi
 	done
 	echo
-	echo -e "\xE2\x9C\x94 $count maps decompressed"
+	echo -e "\xE2\x9C\x94 ${count} maps decompressed"
 }
 
 addLinks() {
@@ -197,11 +197,11 @@ addLinks() {
 	if [[ $desktop_entry =~ ^[Yy]$ || $app_entry =~ ^[Yy]$ ]]; then
 		echo "Creating entry..."
 		echo "[Desktop Entry]" > $launcher_name
-		echo "Version=$patch_ver" >> $launcher_name
-		echo "Name=$game_name" >> $launcher_name
-		echo "Comment=$game_name" >> $launcher_name
-		echo "Exec=$curr_path/$game_folder/System$system_suffix/$game_executable$arc_suffix" >> $launcher_name
-		echo "Icon=$curr_path/$game_folder/System/Unreal.ico" >> $launcher_name
+		echo "Version=${patch_ver}" >> $launcher_name
+		echo "Name=${game_name}" >> $launcher_name
+		echo "Comment=${game_name}" >> $launcher_name
+		echo "Exec=${curr_path}/${game_folder}/System${system_suffix}/${game_executable}${arc_suffix}" >> $launcher_name
+		echo "Icon=${curr_path}/${game_folder}/System/Unreal.ico" >> $launcher_name
 		echo "Terminal=false" >> $launcher_name
 		echo "Type=Application" >> $launcher_name
 		echo "Categories=ApplicationCategory;" >> $launcher_name
@@ -237,9 +237,9 @@ deleteDownFiles() {
 
 addUninstall() {
 	echo "Creating uninstall script..."
-	echo "rm -r ../$game_folder" > uninstall.sh
-	echo "rm ~/Desktop/$launcher_name" >> uninstall.sh
-	echo "rm ~/.local/share/applications/$launcher_name" >> uninstall.sh
+	echo "rm -r ../${game_folder}" > uninstall.sh
+	echo "rm ~/Desktop/${launcher_name}" >> uninstall.sh
+	echo "rm ~/.local/share/applications/${launcher_name}" >> uninstall.sh
 	chmod +x uninstall.sh
 	mv uninstall.sh ./$game_folder
 	echo -e "\xE2\x9C\x94 Uninstall script created"
@@ -255,4 +255,4 @@ addLinks
 deleteDownFiles
 addUninstall
 
-echo -e "\xE2\x9C\x94 Installation completed, execute $game_folder/System$system_suffix/$game_executable$arc_suffix to play"
+echo -e "\xE2\x9C\x94 Installation completed, execute ${game_folder}/System${system_suffix}/${game_executable}${arc_suffix} to play"

--- a/Linux/ut99-installer.sh
+++ b/Linux/ut99-installer.sh
@@ -196,7 +196,7 @@ getPatch() {
 decompressMaps() {
 	echo "Decompressing maps"
 	count=0
-	for file in `ls -1 ${game_folder}/Maps/*.unr.uz`
+	for file in "${game_folder}"/Maps/*.unr.uz
 	do
 		"${game_folder}/System${system_suffix}/ucc-bin-${arc_suffix}" decompress "${curr_path}/${file}" "-nohomedir" > /dev/null 2>&1
 		basename=`echo "$file" | cut -d'/' -f3 | sed 's/\.uz//'`

--- a/Linux/ut99-installer.sh
+++ b/Linux/ut99-installer.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 setVariables() {
-	curr_path=$(pwd)
+	curr_path="$(pwd)"
 	game_executable="ut-bin-"
 	icon_name="Unreal.ico"
 	launcher_name="UT.desktop"
@@ -79,15 +79,15 @@ checkDependencies() {
 }
 
 getUTFiles() {
-	mkdir $game_folder
-	cd $game_folder
+	mkdir "$game_folder"
+	cd "$game_folder"
 
 	echo "Downloading ${game_name} files..."
 	wget -nv --show-progress "$iso_url"
 	echo -e "\xE2\x9C\x94 ${game_name} files downloaded"
 
 	echo "Extracting files..."
-	7z x $iso_name -y
+	7z x "$iso_name" -y
 	echo -e "\xE2\x9C\x94 Files extracted"
 	cd ..
 }
@@ -113,7 +113,7 @@ deleteUnnecessaryFiles() {
 # Patch 469d
 getLatestRelease() {
 	echo "Downloading latest patch release list..."
-	wget -q -O patch_latest $latest_release
+	wget -q -O patch_latest "$latest_release"
 	patch_ver=$(jq -r '.tag_name' ./patch_latest)
 	echo -e "\xE2\x9C\x94 Release list downloaded"
 }
@@ -151,13 +151,13 @@ getPatch() {
 	getLatestRelease
 	getArchitecture
 	echo "Downloading patch ${patch_ver}"
-	wget -P ./$game_folder -nv --show-progress $url_download
+	wget -P "./$game_folder" -nv --show-progress "$url_download"
 	echo -e "\xE2\x9C\x94 Patch downloaded"
 
 	echo "Extracting and adding patch..."
 	patch_tar="./${game_folder}/patch${patch_ver}.tar.bz2"
-	mv ./${game_folder}/*.tar.bz2 $patch_tar
-	tar -xf $patch_tar -C ./${game_folder}/ --overwrite
+	mv ./"${game_folder}"/*.tar.bz2 "$patch_tar"
+	tar -xf "$patch_tar" -C "./${game_folder}/" --overwrite
 	rm ./patch_latest
 	echo -e "\xE2\x9C\x94 Patch added"
 }
@@ -167,14 +167,14 @@ decompressMaps() {
 	count=0
 	for file in `ls -1 ${game_folder}/Maps/*.unr.uz`
 	do
-		${game_folder}/System${system_suffix}/ucc-bin-${arc_suffix} "decompress" "${curr_path}/${file}" "-nohomedir" > /dev/null 2>&1
-		basename=`echo $file | cut -d'/' -f3 | sed 's/\.uz//'`
+		"${game_folder}/System${system_suffix}/ucc-bin-${arc_suffix}" decompress "${curr_path}/${file}" "-nohomedir" > /dev/null 2>&1
+		basename=`echo "$file" | cut -d'/' -f3 | sed 's/\.uz//'`
 		if [ -e "${game_folder}/System${system_suffix}/${basename}" ]
 		then
 			echo -n '.'
 			count=$((count + 1))
 			mv "${game_folder}/System${system_suffix}/${basename}" "${game_folder}/Maps/"
-			rm $file
+			rm "$file"
 		else
 			echo "Failed to decompress ${file}"
 		fi
@@ -187,50 +187,50 @@ addLinks() {
 	read -p "Add a .desktop entry?(Y/n) " desktop_entry
 	read -p "Add a menu entry?(Y/n) " app_entry
 
-	if [[ -z $desktop_entry ]]; then
+	if [[ -z "$desktop_entry" ]]; then
 		desktop_entry='y'
 	fi
-	if [[ -z $app_entry ]]; then
+	if [[ -z "$app_entry" ]]; then
 		app_entry='y'
 	fi
 
-	if [[ $desktop_entry =~ ^[Yy]$ || $app_entry =~ ^[Yy]$ ]]; then
+	if [[ "$desktop_entry" =~ ^[Yy]$ || "$app_entry" =~ ^[Yy]$ ]]; then
 		echo "Creating entry..."
-		echo "[Desktop Entry]" > $launcher_name
-		echo "Version=${patch_ver}" >> $launcher_name
-		echo "Name=${game_name}" >> $launcher_name
-		echo "Comment=${game_name}" >> $launcher_name
-		echo "Exec=${curr_path}/${game_folder}/System${system_suffix}/${game_executable}${arc_suffix}" >> $launcher_name
-		echo "Icon=${curr_path}/${game_folder}/System/Unreal.ico" >> $launcher_name
-		echo "Terminal=false" >> $launcher_name
-		echo "Type=Application" >> $launcher_name
-		echo "Categories=ApplicationCategory;" >> $launcher_name
-		chmod +x $launcher_name
+		echo "[Desktop Entry]" > "$launcher_name"
+		echo "Version=${patch_ver}" >> "$launcher_name"
+		echo "Name=${game_name}" >> "$launcher_name"
+		echo "Comment=${game_name}" >> "$launcher_name"
+		echo "Exec=${curr_path}/${game_folder}/System${system_suffix}/${game_executable}${arc_suffix}" >> "$launcher_name"
+		echo "Icon=${curr_path}/${game_folder}/System/Unreal.ico" >> "$launcher_name"
+		echo "Terminal=false" >> "$launcher_name"
+		echo "Type=Application" >> "$launcher_name"
+		echo "Categories=ApplicationCategory;" >> "$launcher_name"
+		chmod +x "$launcher_name"
 
-		if [[ $desktop_entry =~ ^[Yy]$ ]]; then
-			cp $launcher_name ~/Desktop/
+		if [[ "$desktop_entry" =~ ^[Yy]$ ]]; then
+			cp "$launcher_name" ~/Desktop/
 			echo -e "\xE2\x9C\x94 .desktop entry created"
 		fi
 
-		if [[ $app_entry =~ ^[Yy]$ ]]; then
-			cp $launcher_name ~/.local/share/applications/
+		if [[ "$app_entry" =~ ^[Yy]$ ]]; then
+			cp "$launcher_name" ~/.local/share/applications/
 			echo -e "\xE2\x9C\x94 Menu entry created"
 		fi
-		rm $launcher_name
+		rm "$launcher_name"
 	fi
 }
 
 deleteDownFiles() {
 	read -p "Delete downloaded files?(Y/n) " del_download
 
-	if [[ -z $del_download ]]; then
+	if [[ -z "$del_download" ]]; then
 		del_download='y'
 	fi
 
-	if [[ $del_download =~ ^[Yy]$ ]]; then
+	if [[ "$del_download" =~ ^[Yy]$ ]]; then
 		echo "Deleting downloaded files..."
-		rm $game_folder/$iso_name
-		rm $patch_tar
+		rm "$game_folder/$iso_name"
+		rm "$patch_tar"
 		echo -e "\xE2\x9C\x94 Downloaded files deleted"
 	fi
 }
@@ -241,7 +241,7 @@ addUninstall() {
 	echo "rm ~/Desktop/${launcher_name}" >> uninstall.sh
 	echo "rm ~/.local/share/applications/${launcher_name}" >> uninstall.sh
 	chmod +x uninstall.sh
-	mv uninstall.sh ./$game_folder
+	mv uninstall.sh "./${game_folder}"
 	echo -e "\xE2\x9C\x94 Uninstall script created"
 }
 

--- a/Linux/ut99-installer.sh
+++ b/Linux/ut99-installer.sh
@@ -161,7 +161,7 @@ getPatch() {
 	echo -e "\xE2\x9C\x94 Patch downloaded"
 
 	echo "Extracting and adding patch..."
-	patch_tar="./${game_folder}/patch${patch_ver}.tar.bz2"
+	patch_tar="./${game_folder}/OldUnreal-UTPatch-${patch_ver}-Linux-${arc_suffix}.tar.bz2"
 	mv ./"${game_folder}"/*.tar.bz2 "$patch_tar"
 	tar -xf "$patch_tar" -C "./${game_folder}/" --overwrite
 	rm ./patch_latest

--- a/Linux/ut99-installer.sh
+++ b/Linux/ut99-installer.sh
@@ -28,6 +28,12 @@ dll
 u
 ini
 "
+	if command -v xdg-user-dir >/dev/null 2>&1
+	then
+		desktop_dir=$(xdg-user-dir DESKTOP)
+	else
+		desktop_dir=~/Desktop
+	fi
 }
 
 isInstalled() {
@@ -208,7 +214,7 @@ addLinks() {
 		chmod +x "$launcher_name"
 
 		if [[ "$desktop_entry" =~ ^[Yy]$ ]]; then
-			cp "$launcher_name" ~/Desktop/
+			cp "$launcher_name" "$desktop_dir/"
 			echo -e "\xE2\x9C\x94 .desktop entry created"
 		fi
 
@@ -237,8 +243,8 @@ deleteDownFiles() {
 
 addUninstall() {
 	echo "Creating uninstall script..."
-	echo "rm -r ../${game_folder}" > uninstall.sh
-	echo "rm ~/Desktop/${launcher_name}" >> uninstall.sh
+	echo "rm -r ../$game_folder" > uninstall.sh
+	echo "rm '${desktop_dir}/${launcher_name}'" >> uninstall.sh
 	echo "rm ~/.local/share/applications/${launcher_name}" >> uninstall.sh
 	chmod +x uninstall.sh
 	mv uninstall.sh "./${game_folder}"

--- a/Linux/ut99-installer.sh
+++ b/Linux/ut99-installer.sh
@@ -243,9 +243,10 @@ deleteDownFiles() {
 
 addUninstall() {
 	echo "Creating uninstall script..."
-	echo "rm -r ../$game_folder" > uninstall.sh
-	echo "rm '${desktop_dir}/${launcher_name}'" >> uninstall.sh
-	echo "rm ~/.local/share/applications/${launcher_name}" >> uninstall.sh
+	echo 'cd "$(dirname "$0")"' > uninstall.sh
+	echo "rm -r ../${game_folder}" >> uninstall.sh
+	echo "rm -f '${desktop_dir}/${launcher_name}'" >> uninstall.sh
+	echo "rm -f ~/.local/share/applications/${launcher_name}" >> uninstall.sh
 	chmod +x uninstall.sh
 	mv uninstall.sh "./${game_folder}"
 	echo -e "\xE2\x9C\x94 Uninstall script created"


### PR DESCRIPTION
I've modified the linux installer script from #2 a bit.

Functional improvements:
- Check for dependencies in a cross-distro way
- Do not download UT99 and patch file if they have been downloaded already
- Support translated desktop folder name (per XDG spec)
- Support running the uninstallation script from outside the UT folder

Script improvements:
- `.editorconfig` - see https://editorconfig.org
- Fix tab indentation (remove space indentation)
- Do not use "cat" to pipe data into jq
- Quote variables and change inline quoting mode
- Use "read -r" to silence shellcheck
- Do not warn when windows files cannot be deleted

Feel free to cherry-pick the commits you'd like to use.
If you don't want some commits and they prevent you from cherry-picking later ones, tell me. I'll rebase then.
