### PR TITLE
Fix dependencies on Fedora/RHEL

### DIFF
--- a/Linux/ut99-installer.sh
+++ b/Linux/ut99-installer.sh
@@ -80,8 +80,8 @@ checkDependencies() {
 	checkInstall "jq"
 	checkInstall "tar"
 	checkInstall "unzip"
-	checkInstall "p7zip-full" "p7zip"
-	checkInstall "wget"
+	checkInstall "p7zip-full" "p7zip-plugins"
+	checkInstall "wget" "wget2-wget"
 }
 
 getUTFiles() {


### PR DESCRIPTION
Some notes here:
1. `7z` is actually provided by the package `p7zip-plugins` on Fedora/RHEL
2. The `wget` package has been replaced with the `wget2-wget` package on the recent Fedora distributions