### PR TITLE
Update ut99-installer.sh

### DIFF
--- a/Linux/ut99-installer.sh
+++ b/Linux/ut99-installer.sh
@@ -81,7 +81,7 @@ checkDependencies() {
 	checkInstall "tar"
 	checkInstall "unzip"
 	checkInstall "p7zip-full" "p7zip"
-	checkInstall "wget"
+	checkInstall "wget" "wget2"
 }
 
 getUTFiles() {


### PR DESCRIPTION
Fedora 42 Fails with only wget this package now calls wget2