### PR TITLE
feat: grab latest preview release for Unreal Gold

### DIFF
--- a/Linux/install-unreal.sh
+++ b/Linux/install-unreal.sh
@@ -1301,7 +1301,7 @@ installer::entrypoint() {
   }
 
   # Patch Metadata Download Step
-  PATCH_METADATA_URL="https://api.github.com/repos/OldUnreal/Unreal-testing/releases/tags/v227k_12"
+  PATCH_METADATA_URL="https://api.github.com/repos/OldUnreal/Unreal-testing/releases"
 
   # Download Steps
   # shellcheck disable=SC2034 # Used dynamically below
@@ -1697,10 +1697,22 @@ You may read the Terms of Service at this URL:
       }
     fi
 
+    local IS_GITHUB_RELEASES_ARRAY="no"
+    { IS_GITHUB_RELEASES_ARRAY=$(echo "${PATCH_METADATA_JSON}" | jq -r 'if (. | type) == "array" then "yes" else "no" end'); } || {
+      term::step::failed_with_error "Couldn't determine if we received a single release, or an array of releases. Installation aborted."
+      return 1
+    }
+
+    local JQ_FILTER=".assets[]"
+    if [[ "${IS_GITHUB_RELEASES_ARRAY}" == "yes" ]]; then
+      JQ_FILTER=".[0].assets[]"
+    fi
+
     local METADATA_FILTER
     METADATA_FILTER=$(step::read_patch_meta_from_github::metadata_filter "${PATCH_FOR_OS}" "${ARCHITECTURE_SUFFIX}")
     local JQ_FILTER
-    { JQ_FILTER='.assets[] | select(.browser_download_url | ascii_downcase | contains("'"${METADATA_FILTER}"'"))'; } ||
+
+    { JQ_FILTER+=' | select(.browser_download_url | ascii_downcase | contains("'"${METADATA_FILTER}"'"))'; } ||
       {
         term::step::failed_with_error "Implementation error, step::read_patch_meta_from_github::metadata_filter runtime error."
         return 1

--- a/Linux/src/entrypoints/install-unreal.sh
+++ b/Linux/src/entrypoints/install-unreal.sh
@@ -187,7 +187,7 @@ installer::entrypoint() {
   # @include lib/unarchiver.sh
 
   # Patch Metadata Download Step
-  PATCH_METADATA_URL="https://api.github.com/repos/OldUnreal/Unreal-testing/releases/tags/v227k_12"
+  PATCH_METADATA_URL="https://api.github.com/repos/OldUnreal/Unreal-testing/releases"
 
   # Download Steps
   # shellcheck disable=SC2034 # Used dynamically below

--- a/Linux/src/steps/read_patch_meta_from_github.sh
+++ b/Linux/src/steps/read_patch_meta_from_github.sh
@@ -43,10 +43,22 @@ step::read_patch_meta_from_github() {
     }
   fi
 
+  local IS_GITHUB_RELEASES_ARRAY="no"
+  { IS_GITHUB_RELEASES_ARRAY=$(echo "${PATCH_METADATA_JSON}" | jq -r 'if (. | type) == "array" then "yes" else "no" end'); } || {
+    term::step::failed_with_error "Couldn't determine if we received a single release, or an array of releases. Installation aborted."
+    return 1
+  }
+
+  local JQ_FILTER=".assets[]"
+  if [[ "${IS_GITHUB_RELEASES_ARRAY}" == "yes" ]]; then
+    JQ_FILTER=".[0].assets[]"
+  fi
+
   local METADATA_FILTER
   METADATA_FILTER=$(step::read_patch_meta_from_github::metadata_filter "${PATCH_FOR_OS}" "${ARCHITECTURE_SUFFIX}")
   local JQ_FILTER
-  { JQ_FILTER='.assets[] | select(.browser_download_url | ascii_downcase | contains("'"${METADATA_FILTER}"'"))'; } ||
+
+  { JQ_FILTER+=' | select(.browser_download_url | ascii_downcase | contains("'"${METADATA_FILTER}"'"))'; } ||
     {
       term::step::failed_with_error "Implementation error, step::read_patch_meta_from_github::metadata_filter runtime error."
       return 1


### PR DESCRIPTION
Since there is no latest release in the Unreal-testing repo (only pre-releases), we cannot use the `latest` tag to get the latest release.

This allows the installer to automatically fetch the latest preview.