### PR TITLE
fix(linux): UnrealEd patch URL logic for UT2004

### DIFF
--- a/Linux/install-unreal.sh
+++ b/Linux/install-unreal.sh
@@ -1712,7 +1712,7 @@ You may read the Terms of Service at this URL:
         local PATCH_TARGET_ARCHITECTURE="${2:-}"
 
         if [[ "${PATCH_OS_NAME}" == "windows" ]]; then
-          echo "-${PATCH_OS_NAME}.zip"
+          echo "-${PATCH_OS_NAME}(-.+)?.zip"
           return 0
         fi
 
@@ -1735,7 +1735,7 @@ You may read the Terms of Service at this URL:
     METADATA_FILTER=$(step::read_patch_meta_from_github::metadata_filter "${PATCH_FOR_OS}" "${ARCHITECTURE_SUFFIX}")
     local JQ_FILTER
 
-    { JQ_FILTER+=' | select(.browser_download_url | ascii_downcase | contains("'"${METADATA_FILTER}"'"))'; } ||
+    { JQ_FILTER+=' | select(.browser_download_url | ascii_downcase | test("'"${METADATA_FILTER}"'"))'; } ||
       {
         term::step::failed_with_error "Implementation error, step::read_patch_meta_from_github::metadata_filter runtime error."
         return 1

--- a/Linux/install-ut2004.sh
+++ b/Linux/install-ut2004.sh
@@ -1692,7 +1692,7 @@ You may read the Terms of Service at this URL:
         local PATCH_TARGET_ARCHITECTURE="${2:-}"
 
         if [[ "${PATCH_OS_NAME}" == "windows" ]]; then
-          echo "-${PATCH_OS_NAME}.zip"
+          echo "-${PATCH_OS_NAME}(-.+)?.zip"
           return 0
         fi
 
@@ -1715,7 +1715,7 @@ You may read the Terms of Service at this URL:
     METADATA_FILTER=$(step::read_patch_meta_from_github::metadata_filter "${PATCH_FOR_OS}" "${ARCHITECTURE_SUFFIX}")
     local JQ_FILTER
 
-    { JQ_FILTER+=' | select(.browser_download_url | ascii_downcase | contains("'"${METADATA_FILTER}"'"))'; } ||
+    { JQ_FILTER+=' | select(.browser_download_url | ascii_downcase | test("'"${METADATA_FILTER}"'"))'; } ||
       {
         term::step::failed_with_error "Implementation error, step::read_patch_meta_from_github::metadata_filter runtime error."
         return 1

--- a/Linux/install-ut99.sh
+++ b/Linux/install-ut99.sh
@@ -1735,7 +1735,7 @@ You may read the Terms of Service at this URL:
         local PATCH_TARGET_ARCHITECTURE="${2:-}"
 
         if [[ "${PATCH_OS_NAME}" == "windows" ]]; then
-          echo "-${PATCH_OS_NAME}.zip"
+          echo "-${PATCH_OS_NAME}(-.+)?.zip"
           return 0
         fi
 
@@ -1758,7 +1758,7 @@ You may read the Terms of Service at this URL:
     METADATA_FILTER=$(step::read_patch_meta_from_github::metadata_filter "${PATCH_FOR_OS}" "${ARCHITECTURE_SUFFIX}")
     local JQ_FILTER
 
-    { JQ_FILTER+=' | select(.browser_download_url | ascii_downcase | contains("'"${METADATA_FILTER}"'"))'; } ||
+    { JQ_FILTER+=' | select(.browser_download_url | ascii_downcase | test("'"${METADATA_FILTER}"'"))'; } ||
       {
         term::step::failed_with_error "Implementation error, step::read_patch_meta_from_github::metadata_filter runtime error."
         return 1

--- a/Linux/src/steps/read_patch_meta_from_github.sh
+++ b/Linux/src/steps/read_patch_meta_from_github.sh
@@ -35,7 +35,7 @@ step::read_patch_meta_from_github() {
       local PATCH_TARGET_ARCHITECTURE="${2:-}"
 
       if [[ "${PATCH_OS_NAME}" == "windows" ]]; then
-        echo "-${PATCH_OS_NAME}.zip"
+        echo "-${PATCH_OS_NAME}(-.+)?.zip"
         return 0
       fi
 
@@ -58,7 +58,7 @@ step::read_patch_meta_from_github() {
   METADATA_FILTER=$(step::read_patch_meta_from_github::metadata_filter "${PATCH_FOR_OS}" "${ARCHITECTURE_SUFFIX}")
   local JQ_FILTER
 
-  { JQ_FILTER+=' | select(.browser_download_url | ascii_downcase | contains("'"${METADATA_FILTER}"'"))'; } ||
+  { JQ_FILTER+=' | select(.browser_download_url | ascii_downcase | test("'"${METADATA_FILTER}"'"))'; } ||
     {
       term::step::failed_with_error "Implementation error, step::read_patch_meta_from_github::metadata_filter runtime error."
       return 1


### PR DESCRIPTION
Passing the `-e` /  `--unrealed` option for the UT2004 installer failed. This PR fixes that.