### PR TITLE
feat: fix desktop files for ZorinOS and other OSes who ship with dash

### DIFF
--- a/Linux/install-unreal.desktop
+++ b/Linux/install-unreal.desktop
@@ -1,15 +1,10 @@
 [Desktop Entry]
 Comment=
-Exec=sh -c 'set -euo pipefail; URL="https://raw.githubusercontent.com/OldUnreal/FullGameInstallers/master/Linux/install-unreal.sh"; { if command -v curl &>/dev/null; then curl -LSs --compressed --fail "${URL}"; elif command -v wget &>/dev/null; then wget -q "${URL}" -O -; elif command -v wget2 &>/dev/null; then wget2 -q "${URL}" -O -; fi; } | bash -s -- --application-entry=install'
+Exec=bash -c 'set -euo pipefail; URL="https://raw.githubusercontent.com/OldUnreal/FullGameInstallers/master/Linux/install-unreal.sh"; { if command -v curl &>/dev/null; then curl -LSs --compressed --fail "${URL}"; elif command -v wget &>/dev/null; then wget -q "${URL}" -O -; elif command -v wget2 &>/dev/null; then wget2 -q "${URL}" -O -; fi; } | bash -s -- --application-entry=install'
 GenericName=
 MimeType=
 Name=Install Unreal Gold
 Path=
-StartupNotify=false
 Terminal=true
 TerminalOptions=
 Type=Application
-X-DBUS-ServiceName=
-X-DBUS-StartupType=
-X-KDE-SubstituteUID=false
-X-KDE-Username=

--- a/Linux/install-ut2004.desktop
+++ b/Linux/install-ut2004.desktop
@@ -1,15 +1,10 @@
 [Desktop Entry]
 Comment=
-Exec=sh -c 'set -euo pipefail; URL="https://raw.githubusercontent.com/OldUnreal/FullGameInstallers/master/Linux/install-ut2004.sh"; { if command -v curl &>/dev/null; then curl -LSs --compressed --fail "${URL}"; elif command -v wget &>/dev/null; then wget -q "${URL}" -O -; elif command -v wget2 &>/dev/null; then wget2 -q "${URL}" -O -; fi; } | bash -s -- --application-entry=install'
+Exec=bash -c 'set -euo pipefail; URL="https://raw.githubusercontent.com/OldUnreal/FullGameInstallers/master/Linux/install-ut2004.sh"; { if command -v curl &>/dev/null; then curl -LSs --compressed --fail "${URL}"; elif command -v wget &>/dev/null; then wget -q "${URL}" -O -; elif command -v wget2 &>/dev/null; then wget2 -q "${URL}" -O -; fi; } | bash -s -- --application-entry=install'
 GenericName=
 MimeType=
 Name=Install Unreal Tournament 2004
 Path=
-StartupNotify=false
 Terminal=true
 TerminalOptions=
 Type=Application
-X-DBUS-ServiceName=
-X-DBUS-StartupType=
-X-KDE-SubstituteUID=false
-X-KDE-Username=

--- a/Linux/install-ut99.desktop
+++ b/Linux/install-ut99.desktop
@@ -1,15 +1,11 @@
+#!/usr/bin/env xdg-open
 [Desktop Entry]
 Comment=
-Exec=sh -c 'set -euo pipefail; URL="https://raw.githubusercontent.com/OldUnreal/FullGameInstallers/master/Linux/install-ut99.sh"; { if command -v curl &>/dev/null; then curl -LSs --compressed --fail "${URL}"; elif command -v wget &>/dev/null; then wget -q "${URL}" -O -; elif command -v wget2 &>/dev/null; then wget2 -q "${URL}" -O -; fi; } | bash -s -- --application-entry=install'
+Exec=bash -c 'set -euo pipefail; URL="https://raw.githubusercontent.com/OldUnreal/FullGameInstallers/master/Linux/install-ut99.sh"; { if command -v curl &>/dev/null; then curl -LSs --compressed --fail "${URL}"; elif command -v wget &>/dev/null; then wget -q "${URL}" -O -; elif command -v wget2 &>/dev/null; then wget2 -q "${URL}" -O -; fi; } | bash -s -- --application-entry=install'
 GenericName=
 MimeType=
 Name=Install Unreal Tournament: GOTY
 Path=
-StartupNotify=false
 Terminal=true
 TerminalOptions=
 Type=Application
-X-DBUS-ServiceName=
-X-DBUS-StartupType=
-X-KDE-SubstituteUID=false
-X-KDE-Username=


### PR DESCRIPTION
Fixed issue raised in PR #41 - ZorinOS ships with `dash` instead of `sh` by default, which causes the `.desktop` files to fail.

We expect `bash` to be present anyway, so use that, and remove `StartupNotify` as it is no longer needed.