### PR TITLE
Don't create the desktop shortcuts by default

### DIFF
--- a/Windows/Common.nsh
+++ b/Windows/Common.nsh
@@ -191,7 +191,7 @@ Section
 	!endif
 SectionEnd
 
-Section "Create shortcuts on the Desktop"
+Section /o "Create shortcuts on the Desktop"
 	StrCpy $DesktopLinks "1"
 SectionEnd
 


### PR DESCRIPTION
The Windows logo guidelines say that desktop shortcuts should not be created by installers.