### PR TITLE
Use the correct uninstall page macro

### DIFF
--- a/Windows/Common.nsh
+++ b/Windows/Common.nsh
@@ -172,6 +172,8 @@ FunctionEnd
 !insertmacro MUI_PAGE_INSTFILES
 !insertmacro MUI_PAGE_FINISH
 
+!insertmacro MUI_UNPAGE_INSTFILES
+
 !insertmacro MUI_LANGUAGE "English"
 
 LicenseData "${NOTICE_FILE}"


### PR DESCRIPTION
The uninstall page is not getting its Modern UI elements initialized because the MUI_UNPAGE macro was missing.